### PR TITLE
Fix typo in "Linking private DNS zone"

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ This is an optional feature and only applicable if you are using your own DNS se
 
 ## Linking Hub Private DNS Zone
 
-This module facilitates linking the spoke VNet to private DNS, preferably created by the Spoke Module. To create a link to a private DNS zone, providet the domain name of the private DNS zone to the `private_dns_zones` argument. If you want to link multiple private DNS zones, provide the list of DNS Zones to the `private_dns_zones` argument like this: `private_dns_zones = ["privatelink.blob.core.windows.net", "privatelink.file.core.windows.net"]`  
+This module facilitates linking the spoke VNet to private DNS, preferably created by the Spoke Module. To create a link to a private DNS zone, provide the domain name of the private DNS zone to the `private_dns_zones` argument. If you want to link multiple private DNS zones, provide the list of DNS Zones to the `private_dns_zones` argument like this: `private_dns_zones = ["privatelink.blob.core.windows.net", "privatelink.file.core.windows.net"]`  
 
 ## Recommended naming and tagging conventions
 


### PR DESCRIPTION
Fixed a typo in "Linking Hub Private DNS Zones"

## Describe your changes
Fixing typo

## Issue number

#000

## Checklist before requesting a review
- [ x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

